### PR TITLE
ReduceMotion Media Query support

### DIFF
--- a/_sass/base/_buttons.scss
+++ b/_sass/base/_buttons.scss
@@ -9,7 +9,7 @@
   &,
   &-inner,
   &::after {
-    transition: $default-duration $default-timing-function;
+    @include transition();
   }
 
   &-inner,

--- a/_sass/base/_init.scss
+++ b/_sass/base/_init.scss
@@ -37,12 +37,12 @@ fieldset {
 }
 
 a, button, input, select {
-  transition: $default-duration $default-timing-function;
+  @include transition();
 }
 
 textarea {
   resize: vertical;
-  transition: $default-duration $default-timing-function, height 0s;
+  @include transition('$default-duration $default-timing-function, height 0s');
 }
 
 button {

--- a/_sass/layout/_navigation.scss
+++ b/_sass/layout/_navigation.scss
@@ -18,7 +18,7 @@ $load-third-length: ($nav-menu-width-inactive - ($load-first-start + $load-first
     background-color: $nav-trigger-area-bg;
     opacity: 0; visibility: hidden; content: ''; pointer-events: none;
     cursor: url('../images/cross.png'), zoom-out;
-    transition: $default-duration $default-timing-function;
+    @include transition();
   }
 
   &-button {
@@ -40,7 +40,7 @@ $load-third-length: ($nav-menu-width-inactive - ($load-first-start + $load-first
       position: absolute;
       opacity: 1;
       transform: rotate(0deg);
-      transition: $default-duration $default-timing-function;
+      @include transition();
 
       &.load {
         height: $nav-menu-bar-height;
@@ -136,7 +136,7 @@ $load-third-length: ($nav-menu-width-inactive - ($load-first-start + $load-first
   background-color: $nav-bg;
   font: $default-font-style $default-font-weight 1.5em/#{$default-line-height} $default-font-family; text-align: center;
   opacity: 0; visibility: hidden; content: ''; pointer-events: none;
-  transition: $nav-toggle-duration $nav-toggle-timing-function;
+  @include transition('$nav-toggle-duration $nav-toggle-timing-function');
 
   @include media('>medium') {
     font: $nav-font-style $nav-font-weight 2em/#{$default-line-height} $nav-font-family;

--- a/_sass/scss/_config.scss
+++ b/_sass/scss/_config.scss
@@ -112,6 +112,8 @@ $btn-hpadding               : 1.5em;
 
 // Transitions
 
+$enable-transitions         : true;
+
 $default-duration           : .25s;
 $default-timing-function    : ceaser(easeInOutQuart);
 

--- a/_sass/scss/_mixins.scss
+++ b/_sass/scss/_mixins.scss
@@ -1,0 +1,13 @@
+@mixin transition($transition...) {
+  @if $enable-transitions {
+    @if length($transition) == 0 {
+      transition: $default-duration $default-timing-function;
+    } @else {
+      transition: $transition;
+    }
+  }
+
+  @media screen and (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

Le site contient quelques animations (menu, boutons).

### Quels sont les changement(s) apporté(s) ?

Ce commit détourne tous les `transition` vers une mixin qui supporte la media query ReduceMotion. De cette manière, les utilisateurs souffrant de troubles vestibulaires et disposant d'un navigateur compatible (à ce jour, uniquement Safari) pourront désactiver les animations.

### Qui devrait être prévenu de cette demande ?

@weblovespeed/staff
