### PR TITLE
Remove "(required)", which is already in it's dedicated string

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -78,7 +78,7 @@ en_US:
   "voir la vidéo": "see the video"
   "Voir le programme": "See the line-up"
   "voir le programme": "see the line-up"
-  "Votre email": "Your email (required)"
+  "Votre email": "Your email"
   "Votre nom": "Your name"
   "Votre numéro": "Your email (required)"
 


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

Doublon de "(required)" dans le formulaire d'abonnement sur la home

### Quels sont les changement(s) apporté(s) ?

- suppression de " (required)" de la chaine "Your mail"

### Qui devrait être prévenu de cette demande ?

@weblovespeed/staff
