### PR TITLE
Server-side redirects through Netlify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :jekyll_plugins do
   gem 'liquid-md5'
   gem 'jekyll-microtypo'
   gem 'jekyll-paginate-v2', '~> 1.8', '>= 1.8.1'
-  gem 'jekyll-redirect-from'
   gem 'jekyll-sitemap'
   gem 'octopress-autoprefixer'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,8 +60,6 @@ GEM
       jekyll (>= 3.0, < 4.0)
     jekyll-paginate-v2 (1.9.4)
       jekyll (~> 3.0)
-    jekyll-redirect-from (0.13.0)
-      jekyll (~> 3.3)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-sitemap (1.2.0)
@@ -124,7 +122,6 @@ DEPENDENCIES
   jekyll-github-metadata
   jekyll-microtypo
   jekyll-paginate-v2 (~> 1.8, >= 1.8.1)
-  jekyll-redirect-from
   jekyll-sitemap
   liquid-md5
   octopress-autoprefixer

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,29 @@
+# Permanent
+/sponsors/ /merci/ 301
+/en/sponsors/ /en/thanks/ 301
+
+# Temporary
+/en/blog/ /blog 302
+/en/legal-mentions/ /mentions-legales/ 302
+
+## Redirect to fr if language is fr
+
+/en/banners/ /bannieres/ 302 Language=fr
+/en/register/ /billetterie/ 302 Language=fr
+/en/code-of-conduct/ /code-de-conduite/ 302 Language=fr
+/en/contact/ /contact/ 302 Language=fr
+/en/ / 302 Language=fr
+/en/informations/ /infos-pratiques/ 302 Language=fr
+/en/line-up/ /programme/ 302 Language=fr
+/en/thanks/ /merci/ 302 Language=fr
+
+## Redirect to en if language is en
+
+/bannieres/ /en/banners/ 302 Language=en
+/billetterie/ /en/register/ 302 Language=en
+/code-de-conduite/ /en/code-of-conduct/ 302 Language=en
+/en/contact/ /contact/ 302 Language=en
+/ /en/ 302 Language=en
+/infos-pratiques/ /en/informations/ 302 Language=en
+/programme/ /en/line-up/ 302 Language=en
+/merci/ /en/thanks/ 302 Language=en

--- a/_tasks/postbuild.rake
+++ b/_tasks/postbuild.rake
@@ -19,7 +19,7 @@ namespace :postbuild do
   namespace :test do
     desc 'Test if generated website is valid (do not test external links)'
     task :kiss do
-      sh 'htmlproofer ./_site --disable-external --url-ignore "#,https://www.weezevent.com/?c=sys_widget" --empty-alt-ignore true'
+      sh 'htmlproofer ./_site --disable-external --url-ignore "#,https://www.weezevent.com/?c=sys_widget,/en/legal-mentions/" --empty-alt-ignore true'
     end
 
     desc 'Test if generated website is valid (test external links)'

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,22 +1,4 @@
 (function () {
-
-  // Detect user language and redirect, if first time, to the right page ----------------
-  try {
-    var lang_user;
-
-    lang_user = localStorage.getItem("lang_user");
-    if(!lang_user) {
-      var lang_user = (window.navigator.userLanguage || (window.navigator.languages.length > 0 && window.navigator.languages[0]) || window.navigator.language).slice(0, 2);
-      localStorage.setItem("lang_user", lang_user);
-      var lang_site = document.getElementsByTagName('html')[0].lang;
-      if (lang_user != lang_site){
-        window.location = document.querySelector('[rel="alternate"]').href;
-      }
-    }
-  } catch (e) {
-    console.log("No localstorage, no lang redirection.")
-  }
-
   // Lazyload ---------------------------------------------------------------------------
   var lozadObserver = lozad('.lozad', {
     load: function (el) {

--- a/pages/en/sponsors.html
+++ b/pages/en/sponsors.html
@@ -3,8 +3,6 @@ title: "Our sponsors"
 description: "They chose to support us out of love for UX and Web performance."
 i18n-key: sponsors
 permalink: /en/thanks/
-redirect_from:
-  - /en/sponsors/
 ---
 
 <section class="section">

--- a/pages/fr/blog.html
+++ b/pages/fr/blog.html
@@ -6,6 +6,4 @@ permalink: /blog/
 pagination:
   enabled: true
   locale: fr_FR
-redirect_from:
-  - /en/blog/
 ---

--- a/pages/fr/coc.md
+++ b/pages/fr/coc.md
@@ -4,8 +4,6 @@ description: "Offrir une expérience de conférence sans harcèlement, pour tout
 i18n-key: coc
 permalink: /code-de-conduite/
 layout: page
-redirect_from:
-  - /code-of-conduct/
 ---
 
 # Code de conduite

--- a/pages/fr/mentions-legales.md
+++ b/pages/fr/mentions-legales.md
@@ -3,8 +3,6 @@ title: Mentions légales
 description: "Sud Web est une association de type 1901 à but non-lucratif."
 permalink: /mentions-legales/
 layout: page
-redirect_from:
-  - /en/legal-mentions/
 ---
 
 # {{ page.title }}

--- a/pages/fr/sponsors.html
+++ b/pages/fr/sponsors.html
@@ -3,8 +3,6 @@ title: "Nos sponsors"
 description: "Ils ont choisi de nous soutenir par amour de l'UX et de la performance Web."
 i18n-key: sponsors
 permalink: /merci/
-redirect_from:
-  - /sponsors/
 ---
 
 <section class="section">


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

Redirection côté client en cas de visite sur / depuis un navigateur en EN

### Quels sont les changement(s) apporté(s) ?

- Utilisation des redirections Netlify
- Invalide le besoin pour le plugin jekyll-redirect-from => supprimé
- Invalide le besoin d'une logique client-side de redirection linguistique => supprimée

### Améliorations possible

Le fichier _redirects est contribué à la main. Idéalement, il devrait pouvoir être généré.

### Qui devrait être prévenu de cette demande ?

@weblovespeed/staff
