### PR TITLE
No more tickets, coupons only

### DIFF
--- a/_config_prod.yml
+++ b/_config_prod.yml
@@ -26,8 +26,8 @@ sponsoring:
   en_US: '/assets/docs/2019/sponsoring_en.pdf'
 tickets:
   selling: true
-  weezevent: true
-  coupons-only: false
+  weezevent: false
+  coupons-only: true
   waiting-list: false
   price: "179"
   price_currency: "EUR"


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

Quand le compteur de vente en ligne arriver à 0, nous aurons pourtant encore des coupons sponsors non-réservés. Il faut permettre aux bénéficiaires de les utiliser.

### Quels sont les changement(s) apporté(s) ?

Le formulaire d'achat Weezevent est remplacé par un paragraphe avec un CTA concernant l'utilisation des coupons. Ce CTA pré-rempli le formulaire de contact avec un texte-type que les personnes ont besoin de modifier. Nous recevons alors le mail avec les infos et pouvons vérifier/créer les places dans Weezevent.

Voir en action : https://no-more-tickets--welovespeed.netlify.com/2019/billetterie/

### Qui devrait être prévenu de cette demande ?

@welovespeed/staff
