### PR TITLE
Add ContentSquare as "other sponsor" (small logo, no description)

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -422,3 +422,6 @@
     # - name: BrainCracking
     #   logo: /assets/images/thanks/braincracking.svg
     #   url: http://braincracking.org/
+    - name: Contentsquare
+      logo: /assets/images/thanks/contentsquare.svg
+      url: https://contentsquare.com/

--- a/_includes/sponsors.html
+++ b/_includes/sponsors.html
@@ -16,7 +16,7 @@
     <h3 class="text-center">{% t Nos autres sponsors %}</h3>
     <div class="grid-3 text-center grid-other-sponsors">
       {% for sponsor in site.data.sponsors[include.year].others %}
-        <figure class="company-logo-big">
+        <figure class="company-logo-big{% if site.data.sponsors[include.year].others.size < 2 %} unique-thank{% endif %}">
           <a title="{{ "En savoir plus sur %s" | t: include.locale | replace:"%s",sponsor.name }}" href="{{ sponsor.url }}" rel="sponsored"><img src="{{ sponsor.logo }}" alt="{{sponsor.name}}" loading="lazy" /></a>
         </figure>
       {%- endfor -%}

--- a/_sass/base/_grid.scss
+++ b/_sass/base/_grid.scss
@@ -1,10 +1,15 @@
-[class*=' grid-'],
-[class^='grid-'] {
+[class*=" grid-"],
+[class^="grid-"] {
   --grid-item-min-width: 1fr;
 
   display: grid;
-  grid-template-columns: repeat( auto-fill, minmax( var(--grid-item-min-width), 1fr ) );
-  grid-gap: $global-gutters $global-gutters; justify-items: stretch; align-items: stretch;
+  grid-template-columns: repeat(
+    auto-fill,
+    minmax(var(--grid-item-min-width), 1fr)
+  );
+  grid-gap: $global-gutters $global-gutters;
+  justify-items: stretch;
+  align-items: stretch;
 
   & > * {
     min-width: 0;
@@ -12,10 +17,9 @@
 }
 
 @for $i from 1 through 10 {
-
   $x: ($wrapper-max-width / $i) - $global-gutters;
 
-  @include media('>#{$x}') {
+  @include media(">#{$x}") {
     .grid-#{$i} {
       --grid-item-min-width: #{$x};
     }
@@ -27,7 +31,13 @@
 }
 
 .grid-other-sponsors {
-    @include media('<large') {
+  @include media("<large") {
     --grid-item-min-width: 15rem;
+  }
+
+  @include media(">=large") {
+    .unique-thank {
+      grid-column: 2;
     }
+  }
 }


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

Demande sur Slack :

> Coucou ! Lors de la prochaine maj du site, pourrons-nous ajouter le logo de Contentsquare ? (en plus petit que les autres peut-êtres parce qu’ils sont Silver) : https://brand.contentsquare.com/logotype/

### Quels sont les changement(s) apporté(s) ?

- Ajout de Contentsquare à la liste des "otherSponsors" de 2020
- Modification du markup HTML et CSS pour que le logo d'un sponsor soit centré quand il est le seul de sa catégorie

### Qui devrait être prévenu de cette demande ?

@weblovespeed/staff
