### PR TITLE
Update speaker bio of Josselin BUILS

### DIFF
--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -105,10 +105,10 @@
         url: https://github.com/josselinbuils
     en_US:
       bio: >-
-        Front-end developer @ManoMano_FR. ❤️ JavaScript, TypeScript and dev xp.
+        Josselin has been a front-end developer at ManoMano for 3 years. He actively participated in the redesign of the website via the Spartacux project, especially in the implementation of the new front stack with performance and developer experience as key targets.
     fr_FR:
       bio: >-
-        Front-end developer @ManoMano_FR. ❤️ JavaScript, TypeScript and dev xp.
+        Josselin est dévelopeur front-end chez ManoMano depuis 3 ans. Il a activement participé à la refonte du site web via le projet Spartacux, notament à la mise en place de la nouvelle stack front avec pour objectifs clés la performance et l'expérience dévelopeur.
   nicolas_audemar:
     name: Nicolas Audemar
     image: /assets/images/speakers/2021/nicolas_audemar.jpg


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

Elle met à jour la bio de l'intervenant Josselin BUILS.

### Quels sont les changement(s) apporté(s) ?

Remplacement de la bio Twitter par une bio un peu plus détaillée crée à l'occasion. 

### Qui devrait être prévenu de cette demande ?

@weblovespeed/staff
