### PR TITLE
fix: Updates on Staff links, and content for 2023 edition

### DIFF
--- a/_data/staff.yml
+++ b/_data/staff.yml
@@ -71,10 +71,10 @@
   - firstname: Jérémie
     lastname: Pereira
     slug: jeremie
-    name_link: https://www.linkedin.com/in/jeremiepereira/
+    name_link: https://twitter.com/jeremieP
     links:
-      - label: LinkedIn
-        url: https://www.linkedin.com/in/jeremiepereira/
+      - label: Leboncoin
+        url: https://www.leboncoin.fr
 2021:
   - firstname: Émilie
     lastname: Wilhelm

--- a/pages/fr/2023/billeterie.html
+++ b/pages/fr/2023/billeterie.html
@@ -82,12 +82,12 @@ permalink: /2023/billetterie/
 
 <section class="section">
   <div class="wrapper">
-    <h2>Comment venir à Lyon&nbsp;?</h2>
+    <h2>Comment venir à Paris&nbsp;?</h2>
     <section>
       <p>Nous avons des solutions ! Suivez les conseils que nous vous avons préparé pour un voyage sans encombre.</p>
     </section>
     <p class="text-center">
-      <a class="button" data-text="Venir à Lyon" href="{{ page.baseurl | default:site.baseurl }}/{{ page.year }}/{{ "infos-pratiques" | t: page.locale }}/"><span class="button-inner">Venir à Lyon</span></a>
+      <a class="button" data-text="Venir à Paris" href="{{ page.baseurl | default:site.baseurl }}/{{ page.year }}/{{ "infos-pratiques" | t: page.locale }}/"><span class="button-inner">Venir à Paris</span></a>
     </p>
   </div>
 </section>

--- a/pages/fr/2023/infos-pratiques.md
+++ b/pages/fr/2023/infos-pratiques.md
@@ -12,7 +12,8 @@ layout: page
   {% cloudinary /assets/images/2023/location/3_large.jpg alt="Un auditorium d'environ 300 fauteils, pris en photo depuis son arrière gauche. On y devine un écran géant surplombant un large espace scénique." %}
   <figcaption id="fig1" class="text-xs text-center">
   Le grand auditorium et son large espace scénique.
-</figcaption>
+  </figcaption>
+</figure>
 
 ## Quand ? <span aria-hidden>🕗</span>
 


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

Fixes #103 
Fixes #104 

![Capture d’écran 2023-01-11 à 16 06 29](https://user-images.githubusercontent.com/2271313/211846841-ded1248c-8110-4f07-b93d-96ef8047b2ad.png)

![Capture d’écran 2023-01-11 à 16 30 09](https://user-images.githubusercontent.com/2271313/211846984-11a60e96-04d1-4431-9d69-c94c06cab9a0.png)

### Quels sont les changement(s) apporté(s) ?

- Correction pour afficher la ville de Paris au lieu de Lyon sur la page Billetterie
- Correction du markup pour la page Infos pratiques pour afficher le markdown
- MAJ du lien pour le membre Jeremie P. sur le Staff

Tests are ok after build.

### Qui devrait être prévenu de cette demande ?

@weblovespeed/staff
